### PR TITLE
Skip passwords not matching regex (optional)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,18 @@ pip install pikepdf
 ``` 
 ## Usage
 ```sh
-python crack.py PATH_TO_PDF_FILE [-m MIN_DIGITS] [-n MAX_DIGITS]
+python crack.py PATH_TO_PDF_FILE [-m MIN_DIGITS] [-n MAX_DIGITS] [-r MATCHING_REGEX]
 ``` 
 
-Example - If the password is between 3 to 5 digits long
+Example 1 - If the password is between 3 to 5 digits long
 ```sh
 python crack.py /home/elliot/Desktop/file.pdf -m 3 -n 5
-``` 
+```
+
+Example 2 - Same as above, but tests passwords containing the digits 1-3 **only**
+```sh
+python crack.py /home/elliot/Desktop/file.pdf -m 3 -n 5 -r ^[1-3]+$
+```
 #### This is for educational purpose only, and may not work on all .pdf files.
 
 

--- a/crack.py
+++ b/crack.py
@@ -1,18 +1,21 @@
 from pikepdf import Pdf
 import argparse
+import re
 
-def crack_password(digits, filename):
+def crack_password(digits, filename, pattern):
     n = 1
     n_max = 9999999999999999999 % (10**digits)
     while n < n_max + 1:
         pn = str(n).zfill(digits)
-        try:
-            sample_pdf = Pdf.open(filename_or_stream = filename, password = pn)
-            print("Password is " + pn)
-            return True
-        except:
-            n += 1
-            continue
+        if pattern is None or pattern.match(pn):
+            try:
+                Pdf.open(filename_or_stream = filename, password = pn)
+                print("Password is " + pn)
+                return True
+            except:
+                # incorrect password
+                pass
+        n += 1
     return False
 
 # Parse Commandline Args
@@ -20,6 +23,7 @@ parser = argparse.ArgumentParser(description='Crack numeric passwords of PDFs')
 parser.add_argument('filename', help="Full path of the PDF file")
 parser.add_argument('-m', '--min-digits', help="Minimum digits in the password", type=int, default="1")
 parser.add_argument('-n', '--max-digits', help="Maximum digits in the password", type=int, default="-1")
+parser.add_argument('-r', '--matching-regex', help="Skip passwords not matching regex", type=str, default=None)
 args = parser.parse_args()
 
 # Check and fix min and max digit values
@@ -28,13 +32,19 @@ min_digits = args.min_digits
 if max_digits < min_digits:
     max_digits = min_digits
 
+# Compile and print regex if provided
+pattern = None
+if args.matching_regex is not None:
+    pattern = re.compile(args.matching_regex)
+    print('Skipping passwords not matching:', args.matching_regex)
+
 # Iterate
 digits = min_digits
 found_password = False
 print("Cracking. Please wait...")
 while not found_password and digits <= max_digits:
     print("Trying to crack using " + str(digits) + " digit passwords")
-    found_password = crack_password(digits, args.filename)
+    found_password = crack_password(digits, args.filename, pattern)
     digits += 1
 if not found_password:
     print("Could not crack the password")


### PR DESCRIPTION
Regex can be given with **--matching-regex \<regex>** or **-r \<regex>**. Skips any passwords not matching that regex. 

Default (no regex given): do not skip any passwords (same as existing).

Example usage (my use case): PDF password was supposed to be my DOB in DDMMYYYY format but someone must have mistyped, so only need to check possible birth dates in DDMMYYYY or MMDDYYYY format:

> python3 crack.py -m 8 -n 8 -r \\(\\([0-3][0-9][0-1][0-9]\\)\\|\\([0-1][0-9][0-3][0-9]\\)\)\\(19\\|20\\)[0-9][0-9] my-doc.pdf

(some characters have to be escaped)
